### PR TITLE
force comma dangle on multiline

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = {
   "settings": {
     "react": {
       "createClass": "createReactClass",
-      "pragma": "React"
+      "pragma": "React",
+      "version": "16.4.2"
     }
   },
 
@@ -54,11 +55,11 @@ module.exports = {
     "comma-dangle": [
       "error",
       {
-        "arrays": "never",
-        "objects": "never",
-        "imports": "never",
-        "exports": "never",
-        "functions": "never"
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "always-multiline"
       }
     ],
     "comma-spacing": ["error", { "before": false, "after": true }],


### PR DESCRIPTION
fix comma dangle, since ["Another argument in favor of trailing commas is that it improves the clarity of diffs when an item is added or removed from an object or array"](https://eslint.org/docs/rules/comma-dangle)

bonus: add fix for warning `Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.`

