### PR TITLE
force parens around arrow function params

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = {
 
   "rules": {
     "accessor-pairs": "error",
+    "arrow-parens": ["error", "always"],
     "arrow-spacing": ["error", { "before": true, "after": true }],
     "block-spacing": ["error", "always"],
     "brace-style": ["error", "1tbs", { "allowSingleLine": true }],


### PR DESCRIPTION
force parens around functions so a function always looks like a function. remove optionals

good/consistent:
```
() => {}
(a) => {}
(a, b) => {}
```

inconsistent:
```
() => {}
a => {}
(a, b) => {}
```